### PR TITLE
Let cualloc decide which element types make sense

### DIFF
--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -12,9 +12,7 @@ type CuArray{T,N} <: AbstractArray{T,N}
     len::Int
 
     function CuArray(::Type{T}, shape::NTuple{N,Int})
-        if !isbits(T)
-            throw(ArgumentError("CuArray with non-bit element type not supported"))
-        elseif (sizeof(T) == 0)
+        if (sizeof(T) == 0)
             throw(ArgumentError("CuArray with zero-sized element types does not make sense"))
         end
         len = prod(shape)


### PR DESCRIPTION
 The check in 6a1418 should be sufficient, but the check in the Array constructor is more stringent.

This is needed for the example at https://github.com/JuliaGPU/CUDAnative.jl/blob/3186b236c5ff329ea727318175bb39f7fe2a9800/examples/nvcxx/curand.jl to work.
