### PR TITLE
Fix context finalization

### DIFF
--- a/examples/vadd.jl
+++ b/examples/vadd.jl
@@ -19,3 +19,5 @@ len = prod(dims)
 cudacall(vadd, len, 1, (DevicePtr{Cfloat},DevicePtr{Cfloat},DevicePtr{Cfloat}), d_a, d_b, d_c)
 c = Array(d_c)
 @test a+b ≈ c
+
+destroy(ctx)

--- a/src/CUDAdrv.jl
+++ b/src/CUDAdrv.jl
@@ -7,14 +7,12 @@ import Compat.String
 
 include("util/logging.jl")
 
-include("gc.jl")
-include("pointer.jl")
-
 include("errors.jl")
 include("base.jl")
 include("version.jl")
 include("devices.jl")
 include("context.jl")
+include("pointer.jl")
 include("module.jl")
 include("memory.jl")
 include("stream.jl")
@@ -22,6 +20,7 @@ include("execution.jl")
 include("events.jl")
 include("profile.jl")
 
+include("gc.jl")
 include("array.jl")
 
 

--- a/src/CUDAdrv.jl
+++ b/src/CUDAdrv.jl
@@ -7,6 +7,7 @@ import Compat.String
 
 include("util/logging.jl")
 
+include("gc.jl")
 include("pointer.jl")
 
 include("errors.jl")

--- a/src/array.jl
+++ b/src/array.jl
@@ -26,7 +26,7 @@ type CuArray{T,N} <: AbstractArray{T,N}
 
         ctx = CuCurrentContext()
         obj = new(devptr, shape, len, ctx)
-        track(ctx, obj)
+        gc_track(ctx, obj)
         finalizer(obj, finalize)
 
         obj
@@ -40,7 +40,7 @@ end
 
 function finalize(a::CuArray)
     Mem.free(a.devptr)
-    untrack(a.ctx, a)
+    gc_untrack(a.ctx, a)
 end
 
 (::Type{CuArray{T}}){T,N}(shape::NTuple{N,Int}) = CuArray{T,N}(shape)

--- a/src/array.jl
+++ b/src/array.jl
@@ -9,7 +9,6 @@ export
 type CuArray{T,N} <: AbstractArray{T,N}
     devptr::DevicePtr{T}
     shape::NTuple{N,Int}
-    len::Int
 
     ctx::CuContext
 
@@ -25,7 +24,7 @@ type CuArray{T,N} <: AbstractArray{T,N}
         devptr = Mem.alloc(T, len)
 
         ctx = CuCurrentContext()
-        obj = new(devptr, shape, len, ctx)
+        obj = new(devptr, shape, ctx)
         gc_track(ctx, obj)
         finalizer(obj, finalize)
 
@@ -33,8 +32,7 @@ type CuArray{T,N} <: AbstractArray{T,N}
     end
 
     function CuArray(shape::NTuple{N,Int}, devptr::DevicePtr{T})
-        len = prod(shape)
-        new(devptr, shape, len, CuContext(C_NULL))
+        new(devptr, shape, CuContext(C_NULL))
     end
 end
 
@@ -64,8 +62,8 @@ Base.similar{T,N}(a::CuArray{T}, dims::Dims{N})     = CuArray{T,N}(dims)
 
 ## array interface
 
-Base.length(g::CuArray) = g.len
 Base.size(g::CuArray) = g.shape
+Base.length(g::CuArray) = prod(g.shape)
 
 Base.showarray(io::IO, a::CuArray, repr::Bool = true; kwargs...) =
     Base.showarray(io, Array(a), repr; kwargs...)

--- a/src/array.jl
+++ b/src/array.jl
@@ -49,6 +49,9 @@ end
 function Base.:(==)(a::CuArray, b::CuArray)
     return a.ctx == b.ctx && pointer(a) == pointer(b)
 end
+
+Base.isequal(a::CuArray, b::CuArray) = a == b
+
 Base.unsafe_convert{T}(::Type{DevicePtr{T}}, a::CuArray{T}) = a.devptr
 Base.pointer(a::CuArray) = a.devptr
 
@@ -67,6 +70,11 @@ Base.size(g::CuArray) = g.shape
 Base.showarray(io::IO, a::CuArray, repr::Bool = true; kwargs...) =
     Base.showarray(io, Array(a), repr; kwargs...)
 
+function Base.hash(a::CuArray, h::UInt)
+    h += hash(size(a))
+    h += hash(pointer(a))
+    return h
+end
 
 ## memory management
 

--- a/src/gc.jl
+++ b/src/gc.jl
@@ -1,0 +1,21 @@
+# finalizers are run out-of-order disregarding field references between objects (see
+# JuliaLang/julia#3067), so we manually need to keep instances alive outside of the object
+# fields in order to prevent parent objects getting collected before their children
+
+# NOTE: the Dict is inversed (child => parent), to make the more ccommon track/untrack cheap
+const gc_keepalive = Dict{WeakRef,Any}()
+
+function gc_track(parent::ANY, child::ANY)
+    ref = WeakRef(child)
+    haskey(gc_keepalive, ref) && error("objects can only keep a single parent alive")
+    gc_keepalive[ref] = parent
+end
+
+function gc_untrack(parent::ANY, child::ANY)
+    ref = WeakRef(child)
+    haskey(gc_keepalive, ref) || error("track/untrack mismatch")
+    gc_keepalive[ref] == parent || error("track/untrack mismatch on parent")
+    delete!(gc_keepalive, ref)
+end
+
+gc_children(parent::ANY) = filter((k,v) -> v == parent, gc_keepalive)

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -22,7 +22,7 @@ function alloc(bytesize::Integer)
     ptr_ref = Ref{Ptr{Void}}()
     @apicall(:cuMemAlloc, (Ptr{Ptr{Void}}, Csize_t), ptr_ref, bytesize)
 
-    return Base.unsafe_convert(DevicePtr{Void}, ptr_ref[])
+    return DevicePtr{Void}(ptr_ref[], CuCurrentContext())
 end
 
 """

--- a/src/module/global.jl
+++ b/src/module/global.jl
@@ -18,7 +18,7 @@ immutable CuGlobal{T}
         end
         @assert nbytes_ref[] == sizeof(T)
 
-        return new(Base.unsafe_convert(DevicePtr{Void}, ptr_ref[]), nbytes_ref[])
+        return new(DevicePtr{Void}(ptr_ref[], CuCurrentContext()), nbytes_ref[])
     end
 end
 

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -6,30 +6,35 @@ export
 
 # This wrapper type contains a pointer, but prevents many conversions from and to
 # regular pointers. This ensures we don't mix host and device pointers.
+#
+# It also keep track of the associated context, preventing it from getting freed while
+# there's still a pointer from that context live.
 
 immutable DevicePtr{T}
     ptr::Ptr{T}
+    ctx::CuContext
 
-    DevicePtr(::Ptr{T}) = throw(InexactError())
-    DevicePtr(::Bool, ptr::Ptr{T}) = new(ptr)   # "hidden" constructor, don't use directly
+    DevicePtr(ptr::Ptr{T}, ctx::CuContext) = new(ptr,ctx)
 end
 
-CU_NULL = DevicePtr{Void}(true, C_NULL)
+function Base.:(==)(a::DevicePtr, b::DevicePtr)
+    return a.ctx == b.ctx && a.ptr == b.ptr
+end
+
+CU_NULL = DevicePtr{Void}(C_NULL, CuContext(C_NULL))
 
 # simple conversions between Ptr and DevicePtr are disallowed
-DevicePtr(::Ptr) = throw(InexactError())
 Base.convert{T}(::Type{Ptr{T}}, p::DevicePtr{T}) = throw(InexactError())
 Base.convert{T}(::Type{DevicePtr{T}}, p::Ptr{T}) = throw(InexactError())
 
 # unsafe ones are allowed
 Base.unsafe_convert{T}(::Type{Ptr{T}}, p::DevicePtr{T}) = p.ptr
-Base.unsafe_convert{T}(::Type{DevicePtr{T}}, p::Ptr{T}) = DevicePtr{T}(true, p)
 
 Base.cconvert{P<:DevicePtr}(::Type{P}, x) = x # defer conversions to DevicePtr to unsafe_convert
 
 # conversion between pointers of different types
 Base.convert{T}(::Type{DevicePtr{T}}, p::DevicePtr) =
-    DevicePtr{T}(true, reinterpret(Ptr{T}, p.ptr))
+    DevicePtr{T}(reinterpret(Ptr{T}, p.ptr), p.ctx)
 
 # some convenience methods (which are already defined for Ptr{T},
 # but due to the disallowed conversions we can't use those)

--- a/test/core.jl
+++ b/test/core.jl
@@ -5,14 +5,9 @@ using Compat
 
 ## pointer
 
-# construction
-@test_throws InexactError DevicePtr{Void}(C_NULL)
-@test_throws InexactError DevicePtr(C_NULL)
-
-# conversion
-Base.unsafe_convert(Ptr{Void}, CU_NULL)
+# conversion to Ptr
 @test_throws InexactError convert(Ptr{Void}, CU_NULL)
-@test_throws InexactError convert(DevicePtr{Void}, C_NULL)
+Base.unsafe_convert(Ptr{Void}, CU_NULL)
 
 let
     @test eltype(DevicePtr{Void}) == Void

--- a/test/core.jl
+++ b/test/core.jl
@@ -497,5 +497,5 @@ for i in 1:5
 end
 
 # test there's no outstanding contexts or consumers thereof
-@test length(CUDAdrv.context_consumers) == 0
+@test length(CUDAdrv.gc_keepalive) == 0
 @test length(CUDAdrv.context_instances) == 0


### PR DESCRIPTION
Introduce explicit `destroy` again, and use a global Dict to keep context instances alive. More concretely, it fixes the following case:
```julia
ctx = CuContext()

gc()  # destroys ctx as there's no future use

arr = CuArray(...)   # instantiates new context using CuCurrentContext, but it has been destroyed already!