### PR TITLE
Fix build.jl for windows path names

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -60,7 +60,7 @@ try
     # write ext.jl
     open(ext, "w") do fh
         write(fh, """
-            const libcuda_path = "$libcuda_path"
+            const libcuda_path = "$(escape_string(libcuda_path))"
             const libcuda_version = v"$libcuda_version"
             const libcuda_vendor = "$libcuda_vendor"
             """)


### PR DESCRIPTION
The problem is that otherwise it writes to the file `C:\System\....` so that can't be read back in leading to precompilation problems...