### PR TITLE
Rework primary context again.

### DIFF
--- a/docs/src/lib/api.md
+++ b/docs/src/lib/api.md
@@ -76,7 +76,7 @@ CUDAdrv.CuContext(::CuPrimaryContext)
 CUDAdrv.isactive(::CuPrimaryContext)
 CUDAdrv.flags(::CuPrimaryContext)
 CUDAdrv.setflags!(::CuPrimaryContext, ::CUDAdrv.CUctx_flags)
-CUDAdrv.unsafe_reset!(::CuPrimaryContext)
+CUDAdrv.unsafe_reset!(::CuPrimaryContext, ::Bool)
 ```
 
 

--- a/docs/src/lib/api.md
+++ b/docs/src/lib/api.md
@@ -76,6 +76,7 @@ CUDAdrv.CuContext(::CuPrimaryContext)
 CUDAdrv.isactive(::CuPrimaryContext)
 CUDAdrv.flags(::CuPrimaryContext)
 CUDAdrv.setflags!(::CuPrimaryContext, ::CUDAdrv.CUctx_flags)
+CUDAdrv.unsafe_reset!(::CuPrimaryContext)
 ```
 
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -60,10 +60,10 @@ end
 
 function unsafe_free!(a::CuArray)
     if isvalid(a.devptr.ctx)
-        @trace("Finalizing CuArray at $(Base.pointer_from_objref(a))")
+        @trace("Finalizing CuArray object at $(Base.pointer_from_objref(a))")
         Mem.free(a.devptr)
     else
-        @trace("Skipping finalizer for CuArray at $(Base.pointer_from_objref(a))) because context is no longer valid")
+        @trace("Skipping finalizer for CuArray object at $(Base.pointer_from_objref(a))) because context is no longer valid")
     end
 end
 

--- a/src/context.jl
+++ b/src/context.jl
@@ -71,13 +71,13 @@ const context_instances = Dict{CuContext_t,CuContext}()
 
 isvalid(ctx::CuContext) = ctx.valid
 function invalidate!(ctx::CuContext)
-    @trace("Invalidating CuContext at $(Base.pointer_from_objref(ctx))")
+    @trace("Invalidating CuContext object at $(Base.pointer_from_objref(ctx))")
     ctx.valid = false
     nothing
 end
 
 function unsafe_destroy!(ctx::CuContext)
-    @trace("Finalizing CuContext at $(Base.pointer_from_objref(ctx))")
+    @trace("Finalizing CuContext object at $(Base.pointer_from_objref(ctx))")
     if !ctx.owned
         @trace("Not destroying context $ctx because we don't own it")
     elseif isvalid(ctx)

--- a/src/context/primary.jl
+++ b/src/context/primary.jl
@@ -13,7 +13,7 @@ Create a primary CUDA context for a given device.
 Each primary context is unique per device and is shared with CUDA runtime API. It is meant
 for interoperability with (applications using) the runtime API.
 """
-type CuPrimaryContext
+immutable CuPrimaryContext
     dev::CuDevice
 
     function CuPrimaryContext(dev::CuDevice)

--- a/src/context/primary.jl
+++ b/src/context/primary.jl
@@ -39,13 +39,14 @@ reason, it is advised to use this function with `do` block syntax.
 function CuContext(pctx::CuPrimaryContext)
     handle = Ref{CuContext_t}()
     @apicall(:cuDevicePrimaryCtxRetain, (Ptr{CuContext_t}, CuDevice_t,), handle, pctx.dev)
-    ctx = CuContext(handle[], false)    # CuContext shouldn't destroy this ctx
+    ctx = CuContext(handle[], false)    # CuContext shouldn't manage this ctx
     finalizer(ctx, (ctx)->begin
-        info("yay")
+        @trace("Finalizing derived CuContext object at $(Base.pointer_from_objref(ctx)))")
         @assert isvalid(ctx)    # not owned by CuContext, so shouldn't have been invalidated
         @apicall(:cuDevicePrimaryCtxRelease, (CuDevice_t,), pctx.dev)
         delete!(pctx_instances[pctx], WeakRef(ctx))
         invalidate!(ctx)
+        destroy!(ctx)
     end)
     push!(pctx_instances[pctx], WeakRef(ctx))
     return ctx

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,7 +1,9 @@
 # Deprecated functionality
 
-export devcount, list_devices, destroy
+export devcount, list_devices, destroy, reset
 
 @deprecate devcount() length(devices())
 @deprecate list_devices() map(println, devices())
 @deprecate destroy(ctx::CuContext) destroy!(ctx)
+@deprecate CuPrimaryContext(devnum::Int) CuPrimaryContext(CuDevice(devnum))
+@deprecate reset(pctx::CuPrimaryContext) unsafe_reset!(pctx)

--- a/src/events.jl
+++ b/src/events.jl
@@ -27,10 +27,10 @@ end
 
 function unsafe_destroy!(e::CuEvent)
     if isvalid(e.ctx)
-        @trace("Finalizing CuEvent at $(Base.pointer_from_objref(e))")
+        @trace("Finalizing CuEvent object at $(Base.pointer_from_objref(e))")
         @apicall(:cuEventDestroy, (CuEvent_t,), e)
     else
-        @trace("Skipping finalizer for CuEvent at $(Base.pointer_from_objref(e))) because context is no longer valid.")
+        @trace("Skipping finalizer for CuEvent object at $(Base.pointer_from_objref(e))) because context is no longer valid.")
     end
 end
 

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -35,6 +35,8 @@ const CuDim = Union{Integer,
                     Tuple{Integer, Integer},
                     Tuple{Integer, Integer, Integer}}
 
+# TODO: document ideal default values
+# TODO: unsafe convert voor arrays van en naar cudart?
 """
     launch(f::CuFunction, griddim::CuDim3, blockdim::CuDim3, shmem::Int, stream::CuStream, (args...))
 

--- a/src/module.jl
+++ b/src/module.jl
@@ -59,10 +59,10 @@ end
 
 function unsafe_unload!(mod::CuModule)
     if isvalid(mod.ctx)
-        @trace("Finalizing CuModule at $(Base.pointer_from_objref(mod)))")
+        @trace("Finalizing CuModule object at $(Base.pointer_from_objref(mod)))")
         @apicall(:cuModuleUnload, (CuModule_t,), mod)
     else
-        @trace("Skipping finalizer for CuModule at $(Base.pointer_from_objref(mod))) because context is no longer valid")
+        @trace("Skipping finalizer for CuModule object at $(Base.pointer_from_objref(mod))) because context is no longer valid")
     end
 end
 

--- a/src/module/linker.jl
+++ b/src/module/linker.jl
@@ -45,10 +45,10 @@ end
 
 function unsafe_destroy!(link::CuLink)
     if isvalid(link.ctx)
-        @trace("Finalizing CuLink at $(Base.pointer_from_objref(link))")
+        @trace("Finalizing CuLink object at $(Base.pointer_from_objref(link))")
         @apicall(:cuLinkDestroy, (CuLinkState_t,), link)
     else
-        @trace("Skipping finalizer for CuLink at $(Base.pointer_from_objref(link))) because context is no longer valid")
+        @trace("Skipping finalizer for CuLink object at $(Base.pointer_from_objref(link))) because context is no longer valid")
     end
 end
 

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -34,10 +34,10 @@ end
 
 function unsafe_destroy!(s::CuStream)
     if isvalid(s.ctx)
-        @trace("Finalizing CuStream at $(Base.pointer_from_objref(s))")
+        @trace("Finalizing CuStream object at $(Base.pointer_from_objref(s))")
         @apicall(:cuStreamDestroy, (CuModule_t,), s)
     else
-        @trace("Skipping finalizer for CuStream at $(Base.pointer_from_objref(s)) because context is no longer valid")
+        @trace("Skipping finalizer for CuStream object at $(Base.pointer_from_objref(s)) because context is no longer valid")
     end
 end
 

--- a/test/context.jl
+++ b/test/context.jl
@@ -32,7 +32,7 @@ end
 
 @testset "primary context" begin
 
-pctx = CuPrimaryContext(0)
+pctx = CuPrimaryContext(dev)
 
 @test !isactive(pctx)
 
@@ -41,9 +41,20 @@ setflags!(pctx, CUDAdrv.SCHED_BLOCKING_SYNC)
 @test flags(pctx) == CUDAdrv.SCHED_BLOCKING_SYNC
 
 CuContext(pctx) do ctx
+    @test CUDAdrv.isvalid(ctx)
     @test isactive(pctx)
 end
 gc()
 @test !isactive(pctx)
+
+CuContext(pctx) do ctx
+    @test CUDAdrv.isvalid(ctx)
+    @test isactive(pctx)
+
+    unsafe_reset!(pctx)
+
+    @test !isactive(pctx)
+    @test !CUDAdrv.isvalid(ctx)
+end
 
 end

--- a/test/context.jl
+++ b/test/context.jl
@@ -35,6 +35,8 @@ end
 pctx = CuPrimaryContext(dev)
 
 @test !isactive(pctx)
+unsafe_reset!(pctx)
+@test !isactive(pctx)
 
 @test flags(pctx) == CUDAdrv.SCHED_AUTO
 setflags!(pctx, CUDAdrv.SCHED_BLOCKING_SYNC)


### PR DESCRIPTION
Should be safe to call `reset` now. Next, use it from CUDArt.