### PR TITLE
WIP: debug 0.7 failure

### DIFF
--- a/test/module.jl
+++ b/test/module.jl
@@ -78,6 +78,7 @@ let
     end
 
     obj = complete(link)
+    println(obj.data)
     md = CuModule(obj)
 
     vadd = CuFunction(md, "vadd")


### PR DESCRIPTION
Started happening after 6db340cab4695d0c58e5c1126df3e0a7a6138da8, only reproducible on CI.