### PR TITLE
Fail gracefully when no CUDA available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ notifications:
 env:
   global:
     - DOCUMENTER_DEBUG=true
-    - ONLY_LOAD=true
+    - CUDADRV_ONLY_LOAD=true
 
 after_success:
   - julia -e 'Pkg.add("Documenter")'

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -51,7 +51,7 @@ function find_libcuda()
       warn("CUDA driver library cannot be found (specify the path to $(libcuda_name) using the CUDA_DRIVER environment variable).")
       open(ext, "w") do fh
           write(fh, """
-              ENV["ONLY_LOAD"] = "true"
+              ENV["CUDADRV_ONLY_LOAD"] = "true"
               """)
       end
       exit()

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -47,7 +47,15 @@ function find_libcuda()
             end
         end
     libcuda = Libdl.find_library(libcuda_name, libcuda_locations)
-    isempty(libcuda) && error("CUDA driver library cannot be found (specify the path to $(libcuda_name) using the CUDA_DRIVER environment variable).")
+    if isempty(libcuda)
+      warn("CUDA driver library cannot be found (specify the path to $(libcuda_name) using the CUDA_DRIVER environment variable).")
+      open(ext, "w") do fh
+          write(fh, """
+              ENV["ONLY_LOAD"] = "true"
+              """)
+      end
+      exit()
+    end
 
     # find the full path of the library
     # NOTE: we could just as well use the result of `find_library,
@@ -99,10 +107,4 @@ function main()
     nothing
 end
 
-try
-    main()
-catch ex
-    # if anything goes wrong, wipe the existing ext.jl to prevent the package from loading
-    rm(ext; force=true)
-    rethrow(ex)
-end
+main()

--- a/src/CUDAdrv.jl
+++ b/src/CUDAdrv.jl
@@ -7,7 +7,7 @@ using Compat.String
 
 include("../deps/ext.jl")
 
-const ONLY_LOAD = haskey(ENV, "ONLY_LOAD")
+const ONLY_LOAD = haskey(ENV, "CUDADRV_ONLY_LOAD")
 
 if ONLY_LOAD
     # special mode where the package is loaded without requiring a successful build.

--- a/src/CUDAdrv.jl
+++ b/src/CUDAdrv.jl
@@ -12,7 +12,6 @@ const ONLY_LOAD = haskey(ENV, "ONLY_LOAD")
 if ONLY_LOAD
     # special mode where the package is loaded without requiring a successful build.
     # this is useful for loading in unsupported environments, eg. Travis + Documenter.jl
-    warn("Only loading the package, without activating any functionality.")
     const libcuda_path = ""
     const libcuda_version = v"999"  # make sure all functions are available
 end

--- a/src/CUDAdrv.jl
+++ b/src/CUDAdrv.jl
@@ -5,17 +5,16 @@ module CUDAdrv
 using Compat
 using Compat.String
 
-const ext = joinpath(dirname(@__DIR__), "deps", "ext.jl")
-if isfile(ext)
-    include(ext)
-elseif haskey(ENV, "ONLY_LOAD")
+include("../deps/ext.jl")
+
+const ONLY_LOAD = haskey(ENV, "ONLY_LOAD")
+
+if ONLY_LOAD
     # special mode where the package is loaded without requiring a successful build.
     # this is useful for loading in unsupported environments, eg. Travis + Documenter.jl
     warn("Only loading the package, without activating any functionality.")
     const libcuda_path = ""
     const libcuda_version = v"999"  # make sure all functions are available
-else
-    error("Unable to load dependency file $ext.\nPlease run Pkg.build(\"CUDAdrv\") and restart Julia.")
 end
 const libcuda = libcuda_path
 

--- a/src/init.jl
+++ b/src/init.jl
@@ -11,7 +11,7 @@ function init(flags::Int=0)
 end
 
 function __init__()
-    haskey(ENV, "ONLY_LOAD") && return
+    ONLY_LOAD && return
 
     # check validity of CUDA library
     @debug("Checking validity of $(libcuda_path)")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
-haskey(ENV, "CUDADRV_ONLY_LOAD") && exit()
-
 using CUDAdrv
 using Base.Test
+
+CUDAdrv.ONLY_LOAD && exit()
 
 using Compat
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-haskey(ENV, "ONLY_LOAD") && exit()
+haskey(ENV, "CUDADRV_ONLY_LOAD") && exit()
 
 using CUDAdrv
 using Base.Test


### PR DESCRIPTION
This patch makes the package installable and loadable on machines without CUDA. This is desirable so that downstream packages don't have to do conditional loading hacks to get CPU-only setups.