### PR TITLE
Support for loading/testing the package if the build failed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ notifications:
 env:
   global:
     - DOCUMENTER_DEBUG=true
-    - ONLY_LOAD=true
 
 after_success:
   - julia -e 'Pkg.add("Documenter")'

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,11 +29,15 @@ At the Julia REPL:
 ```julia
 Pkg.add("CUDAdrv")
 using CUDAdrv
+
+# optionally
+Pkg.test("CUDAdrv")
 ```
 
-Building and loading CUDAdrv might display warnings, indicating issues with your set-up.
-Please pay close attention to these, as they might prevent CUDAdrv.jl, or even all of CUDA,
-to work properly! Some possible issues:
+Building CUDAdrv might display error messages, indicating issues with your set-up. These
+messages can be cryptic as they happen too early for decent error handling to be loaded.
+However, please pay close attention to them as they might prevent CUDAdrv.jl from working
+properly! Some common issues:
 
 * unknown error (code 999): this often indicates that your set-up is broken, eg. because you
   didn't load the correct, or any, kernel module. Please verify your set-up, on Linux by
@@ -51,4 +55,7 @@ to work properly! Some possible issues:
   purposefully added the stub libraries to the search path, please run the build script with
   `DEBUG=1` and file a bug report.
 
-Optionally, run the tests using `Pkg.test("CUDAdrv")`.
+Even if the build fails, CUDAdrv.jl should always be loadable. This simplifies use by
+downstream packages, until there is proper language support for conditional modules. You can
+check whether the package has been built properly by inspecting the `CUDAdrv.configured`
+global variable.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -28,21 +28,27 @@ At the Julia REPL:
 
 ```julia
 Pkg.add("CUDAdrv")
-Pkg.test("CUDAdrv")
+using CUDAdrv
 ```
 
-CUDAdrv can throw errors during build. These errors tend to be cryptic, as the library isn't
-loaded yet and we can't look-up the string for a given error code. Common errors include:
+Building and loading CUDAdrv might display warnings, indicating issues with your set-up.
+Please pay close attention to these, as they might prevent CUDAdrv.jl, or even all of CUDA,
+to work properly! Some possible issues:
 
-* Code 999 (`UNKNOWN_ERROR`): this often indicates that your set-up is broken, eg. because
-  you didn't load the correct, or any, kernel module. Please verify your set-up, on Linux by
+* unknown error (code 999): this often indicates that your set-up is broken, eg. because you
+  didn't load the correct, or any, kernel module. Please verify your set-up, on Linux by
   executing `nvidia-smi` or on other platforms by compiling and running CUDA C code using
   `nvcc`.
-* Code 100 (`ERROR_NO_DEVICE`): CUDA didn't detect your device, because it is not supported
-  by CUDA or because you loaded the wrong kernel driver (eg. legacy when you need regular,
-  or vice-versa). CUDAdrv cannot work in this case, because CUDA does not allow us to query
+* no device (code 100): CUDA didn't detect your device, because it is not supported by CUDA
+  or because you loaded the wrong kernel driver (eg. legacy when you need regular, or
+  vice-versa). CUDAdrv.jl cannot work in this case, because CUDA does not allow us to query
   the driver version without a valid device, something we need in order to version the API
   calls.
-* Code -1 (not a valid CUDA error): this error shouldn't ever be thrown by any CUDA API
-  function. Possibly, CUDAdrv might have selected the library stubs instead, which always
-  return -1. Please run the build script with `DEBUG=1` and file a bug report.
+* using library stubs (code -1): if any API call returns -1, you're probably using the CUDA
+  driver library stubs which return this value for every function call. This is not
+  supported by CUDAdrv.jl, and is only intended to be used when compiling C or C++ code to
+  be linked with `libcuda.so` at a time when that library isn't available yet. Unless you
+  purposefully added the stub libraries to the search path, please run the build script with
+  `DEBUG=1` and file a bug report.
+
+Optionally, run the tests using `Pkg.test("CUDAdrv")`.

--- a/src/CUDAdrv.jl
+++ b/src/CUDAdrv.jl
@@ -6,16 +6,16 @@ using Compat
 using Compat.String
 
 const ext = joinpath(dirname(@__DIR__), "deps", "ext.jl")
-if isfile(ext)
+const configured = if isfile(ext)
     include(ext)
-elseif haskey(ENV, "ONLY_LOAD")
-    # special mode where the package is loaded without requiring a successful build.
-    # this is useful for loading in unsupported environments, eg. Travis + Documenter.jl
-    warn("Only loading the package, without activating any functionality.")
-    const libcuda_path = ""
-    const libcuda_version = v"999"  # make sure all functions are available
+    true
 else
-    error("Unable to load dependency file $ext.\nPlease run Pkg.build(\"CUDAdrv\") and restart Julia.")
+    # enable CUDAdrv.jl to be loaded when the build failed, simplifying downstream use.
+    # remove this when we have proper support for conditional modules.
+    const libcuda_version = v"5.5"
+    const libcuda_vendor = "none"
+    const libcuda_path = nothing
+    false
 end
 const libcuda = libcuda_path
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -117,7 +117,12 @@ macro apicall(fun, argtypes, args...)
         error("first argument to @apicall should be a symbol")
     end
 
-    api_fun = resolve(fun.args[1])
+    api_fun = resolve(fun.args[1])  # TODO: make this error at runtime?
+
+    if libcuda == nothing
+        return :(error("CUDAdrv.jl has not been configured."))
+    end
+
     return quote
         status = @logging_ccall($(QuoteNode(api_fun)), ($(QuoteNode(api_fun)), libcuda),
                                 Cint, $(esc(argtypes)), $(map(esc, args)...))

--- a/src/init.jl
+++ b/src/init.jl
@@ -11,15 +11,19 @@ function init(flags::Int=0)
 end
 
 function __init__()
-    haskey(ENV, "ONLY_LOAD") && return
+    __init_logging__()
+
+    if !configured
+        warn("CUDAdrv.jl has not been configured, and will not work properly.")
+        warn("Please run Pkg.build(\"CUDAdrv\") and restart Julia.")
+        return
+    end
 
     # check validity of CUDA library
     @debug("Checking validity of $(libcuda_path)")
     if version() != libcuda_version
-        error("CUDA library version has changed. Please re-run Pkg.build(\"CUDAdrv\") and restart Julia.")
+        error("CUDA driver library has changed. Please run Pkg.build(\"CUDAdrv\") and restart Julia.")
     end
-
-    __init_logging__()
 
     if haskey(ENV, "_") && basename(ENV["_"]) == "rr"
         warn("Running under rr, which is incompatible with CUDA; disabling initialization.")

--- a/test/base.jl
+++ b/test/base.jl
@@ -12,7 +12,9 @@
     end
 )
 
-@test_throws_cuerror CUDAdrv.ERROR_INVALID_DEVICE CUDAdrv.@apicall(:cuDeviceGet, (Ptr{CUDAdrv.CuDevice_t}, Cint), Ref{CUDAdrv.CuDevice_t}(), length(devices()))
+if CUDAdrv.configured
+    @test_throws_cuerror CUDAdrv.ERROR_INVALID_DEVICE CUDAdrv.@apicall(:cuDeviceGet, (Ptr{CUDAdrv.CuDevice_t}, Cint), Ref{CUDAdrv.CuDevice_t}(), length(devices()))
+end
 
 CUDAdrv.vendor()
 

--- a/test/documentation.jl
+++ b/test/documentation.jl
@@ -1,23 +1,27 @@
-@testset "documentation" begin
+if "Documenter" in Pkg.available()
+    @testset "documentation" begin
 
-out = Pipe()
-result = cd(joinpath(dirname(@__DIR__), "docs")) do
-    withenv("TEST"=>true) do
-        cmd = julia_cmd(`make.jl`)
-        success(pipeline(cmd; stdout=out, stderr=out))
+    out = Pipe()
+    result = cd(joinpath(dirname(@__DIR__), "docs")) do
+        withenv("TEST"=>true) do
+            cmd = julia_cmd(`make.jl`)
+            success(pipeline(cmd; stdout=out, stderr=out))
+        end
     end
-end
-close(out.in)
+    close(out.in)
 
-output = readstring(out)
-println(output)
+    output = readstring(out)
+    println(output)
 
-if !result
-    error("error making documentation")    
-end
+    if !result
+        error("error making documentation")    
+    end
 
-if contains(output, "Test Error")
-    error("error running doctests")    
-end
+    if contains(output, "Test Error")
+        error("error running doctests")    
+    end
 
+    end
+else
+    warn("Documenter.jl not installed, skipping documentation tests.")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,47 +1,49 @@
-haskey(ENV, "ONLY_LOAD") && exit()
-
 using CUDAdrv
 using Base.Test
 
 using Compat
 
-include("util.jl")
-
 @testset "CUDAdrv" begin
 
-include("pointer.jl")
+include("util.jl")
+
 include("base.jl")
+include("pointer.jl")
 
-@test length(devices()) > 0
-if length(devices()) > 0
-    # pick most recent device (based on compute capability)
-    global dev = nothing
-    for newdev in devices()
-        if dev == nothing || capability(newdev) > capability(dev)
-            dev = newdev
+if CUDAdrv.configured
+    @test length(devices()) > 0
+    if length(devices()) > 0
+        # pick most recent device (based on compute capability)
+        global dev = nothing
+        for newdev in devices()
+            if dev == nothing || capability(newdev) > capability(dev)
+                dev = newdev
+            end
         end
+        info("Testing using device $(name(dev))")
+        global ctx = CuContext(dev, CUDAdrv.SCHED_BLOCKING_SYNC)
+
+        @testset "API wrappers" begin
+            include("errors.jl")
+            include("version.jl")
+            include("devices.jl")
+            include("context.jl")
+            include("module.jl")
+            include("memory.jl")
+            include("stream.jl")
+            include("execution.jl")
+            include("events.jl")
+            include("profile.jl")
+        end
+
+        include("array.jl")
+        include("gc.jl")
+
+        include("examples.jl")
+        include("documentation.jl")
     end
-    info("Testing using device $(name(dev))")
-    global ctx = CuContext(dev, CUDAdrv.SCHED_BLOCKING_SYNC)
-
-    @testset "API wrappers" begin
-        include("errors.jl")
-        include("version.jl")
-        include("devices.jl")
-        include("context.jl")
-        include("module.jl")
-        include("memory.jl")
-        include("stream.jl")
-        include("execution.jl")
-        include("events.jl")
-        include("profile.jl")
-    end
-
-    include("array.jl")
-    include("gc.jl")
-
-    include("examples.jl")
-    include("documentation.jl")
+else
+    warn("CUDAdrv.jl has not been configured; skipping most tests.")
 end
 
 end


### PR DESCRIPTION
Alternative to #48:
- supports loading/testing the package if the build failed (ie no `ext.jl`), only failing upon actual API calls
- ditches `ONLY_LOAD`/`CUDADRV_ONLY_LOAD` flags

Also:
- supports running tests without Documenter
- eagerly decodes some of the build error codes (to avoid user confusion)