### PR TITLE
Rework and internalize DevicePtr

### DIFF
--- a/docs/src/lib/api.md
+++ b/docs/src/lib/api.md
@@ -118,14 +118,14 @@ CUDAdrv.CuModule(::CUDAdrv.CuLinkImage, args...)
 
 ```@docs
 CUDAdrv.Mem.alloc(::Integer)
-CUDAdrv.Mem.free(::OwnedPtr)
+CUDAdrv.Mem.free(::CUDAdrv.OwnedPtr)
 CUDAdrv.Mem.info
 CUDAdrv.Mem.total
 CUDAdrv.Mem.used
 CUDAdrv.Mem.free()
 CUDAdrv.Mem.set
-CUDAdrv.Mem.upload(::OwnedPtr, ::Ref, ::Integer)
-CUDAdrv.Mem.download(::Ref, ::OwnedPtr, ::Integer)
+CUDAdrv.Mem.upload(::CUDAdrv.OwnedPtr, ::Ref, ::Integer)
+CUDAdrv.Mem.download(::Ref, ::CUDAdrv.OwnedPtr, ::Integer)
 CUDAdrv.Mem.transfer
 ```
 
@@ -133,8 +133,8 @@ CUDAdrv.Mem.transfer
 
 ```@docs
 CUDAdrv.Mem.alloc(::Type, ::Integer)
-CUDAdrv.Mem.upload{T}(::OwnedPtr{T}, ::T)
-CUDAdrv.Mem.download(::OwnedPtr)
+CUDAdrv.Mem.upload{T}(::CUDAdrv.OwnedPtr{T}, ::T)
+CUDAdrv.Mem.download(::CUDAdrv.OwnedPtr)
 ```
 
 ## Stream Management

--- a/docs/src/lib/api.md
+++ b/docs/src/lib/api.md
@@ -118,14 +118,14 @@ CUDAdrv.CuModule(::CUDAdrv.CuLinkImage, args...)
 
 ```@docs
 CUDAdrv.Mem.alloc(::Integer)
-CUDAdrv.Mem.free(::DevicePtr)
+CUDAdrv.Mem.free(::OwnedPtr)
 CUDAdrv.Mem.info
 CUDAdrv.Mem.total
 CUDAdrv.Mem.used
 CUDAdrv.Mem.free()
 CUDAdrv.Mem.set
-CUDAdrv.Mem.upload(::DevicePtr, ::Ref, ::Integer)
-CUDAdrv.Mem.download(::Ref, ::DevicePtr, ::Integer)
+CUDAdrv.Mem.upload(::OwnedPtr, ::Ref, ::Integer)
+CUDAdrv.Mem.download(::Ref, ::OwnedPtr, ::Integer)
 CUDAdrv.Mem.transfer
 ```
 
@@ -133,8 +133,8 @@ CUDAdrv.Mem.transfer
 
 ```@docs
 CUDAdrv.Mem.alloc(::Type, ::Integer)
-CUDAdrv.Mem.upload{T}(::DevicePtr{T}, ::T)
-CUDAdrv.Mem.download(::DevicePtr)
+CUDAdrv.Mem.upload{T}(::OwnedPtr{T}, ::T)
+CUDAdrv.Mem.download(::OwnedPtr)
 ```
 
 ## Stream Management

--- a/examples/vadd.jl
+++ b/examples/vadd.jl
@@ -18,7 +18,7 @@ d_b = CuArray(b)
 d_c = similar(d_a)
 
 len = prod(dims)
-cudacall(vadd, len, 1, Tuple{DevicePtr{Cfloat},DevicePtr{Cfloat},DevicePtr{Cfloat}}, d_a, d_b, d_c)
+cudacall(vadd, len, 1, Tuple{Ptr{Cfloat},Ptr{Cfloat},Ptr{Cfloat}}, d_a, d_b, d_c)
 c = Array(d_c)
 @test a+b ≈ c
 

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -6,7 +6,7 @@ export
 module Mem
 
 using CUDAdrv
-import CUDAdrv: @apicall
+import CUDAdrv: @apicall, OwnedPtr
 
 
 ## pointer-based

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -1,8 +1,5 @@
 # Context-owned pointer
 
-export
-    OwnedPtr, CU_NULL
-
 # Wrapper pointer type to keep track of the associated context, to avoid destroying
 # the context while there's still outstanding references to its memory.
 @compat immutable OwnedPtr{T}
@@ -15,8 +12,6 @@ end
 function Base.:(==)(a::OwnedPtr, b::OwnedPtr)
     return a.ctx == b.ctx && a.ptr == b.ptr
 end
-
-const CU_NULL = OwnedPtr{Void}(C_NULL, CuContext(C_NULL))
 
 # simple conversions between Ptr and OwnedPtr are disallowed
 Base.convert{T}(::Type{Ptr{T}}, p::OwnedPtr{T}) = throw(InexactError())

--- a/test/array.jl
+++ b/test/array.jl
@@ -59,7 +59,7 @@ let
 
     # conversions
     let
-        ptr = convert(OwnedPtr{Int}, CU_NULL)
+        ptr = CUDAdrv.OwnedPtr{Int}(convert(Ptr{Int}, C_NULL), CuContext(C_NULL))
         @test Base.unsafe_convert(Ptr{Int}, CuArray{Int,1}((1,), ptr)) == C_NULL
         @test pointer(CuArray{Int,1}((1,), ptr)) == ptr
     end

--- a/test/array.jl
+++ b/test/array.jl
@@ -4,8 +4,8 @@ let
     # inner constructors
     let
         arr = CuArray{Int,1}((2,))
-        devptr = arr.devptr
-        CuArray{Int,1}((2,), devptr)
+        ptr = arr.ptr
+        CuArray{Int,1}((2,), ptr)
     end
 
     # outer constructors
@@ -59,9 +59,9 @@ let
 
     # conversions
     let
-        devptr = convert(DevicePtr{Int}, CU_NULL)
-        @test Base.unsafe_convert(DevicePtr{Int}, CuArray{Int,1}((1,), devptr)) == devptr
-        @test pointer(CuArray{Int,1}((1,), devptr)) == devptr
+        ptr = convert(OwnedPtr{Int}, CU_NULL)
+        @test Base.unsafe_convert(Ptr{Int}, CuArray{Int,1}((1,), ptr)) == C_NULL
+        @test pointer(CuArray{Int,1}((1,), ptr)) == ptr
     end
 
     # copy: size mismatches

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -64,7 +64,7 @@ let
     let
         c = zeros(Float32, 10)
         cd = CuArray(c)
-        cudacall(vadd, 10, 1, (DevicePtr{Cfloat},DevicePtr{Cfloat},DevicePtr{Cfloat}), ad, bd, cd)
+        cudacall(vadd, 10, 1, (Ptr{Cfloat},Ptr{Cfloat},Ptr{Cfloat}), ad, bd, cd)
         c = Array(cd)
         @test c ≈ a+b
     end
@@ -73,7 +73,7 @@ let
     let
         c = zeros(Float32, 10)
         cd = CuArray(c)
-        cudacall(vsub, 10, 1, (DevicePtr{Cfloat},DevicePtr{Cfloat},DevicePtr{Cfloat}), ad, bd, cd)
+        cudacall(vsub, 10, 1, (Ptr{Cfloat},Ptr{Cfloat},Ptr{Cfloat}), ad, bd, cd)
         c = Array(cd)
         @test c ≈ a-b
     end
@@ -82,7 +82,7 @@ let
     let
         c = zeros(Float32, 10)
         cd = CuArray(c)
-        cudacall(vmul, 10, 1, (DevicePtr{Cfloat},DevicePtr{Cfloat},DevicePtr{Cfloat}), ad, bd, cd)
+        cudacall(vmul, 10, 1, (Ptr{Cfloat},Ptr{Cfloat},Ptr{Cfloat}), ad, bd, cd)
         c = Array(cd)
         @test c ≈ a.*b
     end
@@ -91,7 +91,7 @@ let
     let
         c = zeros(Float32, 10)
         cd = CuArray(c)
-        cudacall(vdiv, 10, 1, (DevicePtr{Cfloat},DevicePtr{Cfloat},DevicePtr{Cfloat}), ad, bd, cd)
+        cudacall(vdiv, 10, 1, (Ptr{Cfloat},Ptr{Cfloat},Ptr{Cfloat}), ad, bd, cd)
         c = Array(cd)
         @test c ≈ a./b
     end

--- a/test/memory.jl
+++ b/test/memory.jl
@@ -33,7 +33,7 @@ end
 
 let
     dev_array = CuArray{Int32}(10)
-    Mem.set(dev_array.devptr, UInt32(0), 10)
+    Mem.set(dev_array.ptr, UInt32(0), 10)
     host_array = Array(dev_array)
 
     @test all(x -> x==0, host_array)

--- a/test/pointer.jl
+++ b/test/pointer.jl
@@ -1,16 +1,16 @@
 @testset "pointer" begin
 
+const CU_NULL = CUDAdrv.OwnedPtr{Void}(C_NULL, CuContext(C_NULL))
+
 # conversion to Ptr
 @test_throws InexactError convert(Ptr{Void}, CU_NULL)
 Base.unsafe_convert(Ptr{Void}, CU_NULL)
 
-let
-    @test eltype(OwnedPtr{Void}) == Void
-    @test eltype(CU_NULL) == Void
-    @test isnull(CU_NULL)
+@test eltype(CUDAdrv.OwnedPtr{Void}) == Void
+@test eltype(CU_NULL) == Void
+@test isnull(CU_NULL)
 
-    @test_throws InexactError convert(Ptr{Void}, CU_NULL)
-    @test_throws InexactError convert(OwnedPtr{Void}, C_NULL)
-end
+@test_throws InexactError convert(Ptr{Void}, CU_NULL)
+@test_throws InexactError convert(CUDAdrv.OwnedPtr{Void}, C_NULL)
 
 end

--- a/test/pointer.jl
+++ b/test/pointer.jl
@@ -5,12 +5,12 @@
 Base.unsafe_convert(Ptr{Void}, CU_NULL)
 
 let
-    @test eltype(DevicePtr{Void}) == Void
+    @test eltype(OwnedPtr{Void}) == Void
     @test eltype(CU_NULL) == Void
     @test isnull(CU_NULL)
 
     @test_throws InexactError convert(Ptr{Void}, CU_NULL)
-    @test_throws InexactError convert(DevicePtr{Void}, C_NULL)
+    @test_throws InexactError convert(OwnedPtr{Void}, C_NULL)
 end
 
 end


### PR DESCRIPTION
This PR renames `DevicePtr` to `OwnedPtr`, and makes it an internal implementation detail. This impacts `cudacall` invocations, which now need to use `Ptr` instead of `DevicePtr`, because this actually matches the C type signature of kernel functions (as well as being easier to use, cfr. `ccall`). As such, this'll probably break some downstream packages (most notably CUDArt).