### PR TITLE
Fix Compat requirement.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
-Compat 0.39.0
+Compat 0.46.0
 CUDAapi 0.3.0


### PR DESCRIPTION
0.46.0 is necessary for the Void deprecation (fixes #80).