### PR TITLE
Safeguard against changing libraries.

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -13,9 +13,7 @@ end
 function __init__()
     configured || return
 
-    # check validity of CUDA library
-    @debug("Checking validity of $(libcuda_path)")
-    if version() != libcuda_version
+    if !ispath(libcuda) || version() != libcuda_version
         error("CUDA driver library has changed. Please run Pkg.build(\"CUDAdrv\") and restart Julia.")
     end
 


### PR DESCRIPTION
With https://github.com/JuliaGPU/CUDAapi.jl/pull/61 we'll be picking up versioned libraries, so make sure they still exist.