### PR TITLE
Implementation of pinned memory allocation

### DIFF
--- a/src/context/primary.jl
+++ b/src/context/primary.jl
@@ -3,7 +3,7 @@
 # This is meant for interoperability with the CUDA runtime API
 
 export
-    CuPrimaryContext, unsafe_reset!, isactive, flags, setflags!
+    CuPrimaryContext, unsafe_reset!, isactive, flags, setflags!, resetPrimaryContext!
 
 """
     CuPrimaryContext(dev::CuDevice)
@@ -104,6 +104,15 @@ function unsafe_reset!(pctx::CuPrimaryContext, checked::Bool=true)
     end
 
     return
+end
+
+# Although excluded for reasons above, having the option to reset primary context is
+# useful nonetheless under certain circumstances.
+"""Resets the primary context on the selected device. Useful if GC fails to
+pick-up old handles despite destroying current ctx. WARNING: This can break
+automatic GC handling. Use at your own risk."""
+function resetPrimaryContext!(dev::CuDevice)
+    @apicall(:cuDevicePrimaryCtxReset, (CuDevice_t,), dev )
 end
 
 """

--- a/src/context/primary.jl
+++ b/src/context/primary.jl
@@ -3,7 +3,7 @@
 # This is meant for interoperability with the CUDA runtime API
 
 export
-    CuPrimaryContext, unsafe_reset!, isactive, flags, setflags!, resetPrimaryContext!
+    CuPrimaryContext, unsafe_reset!, isactive, flags, setflags!
 
 """
     CuPrimaryContext(dev::CuDevice)
@@ -104,15 +104,6 @@ function unsafe_reset!(pctx::CuPrimaryContext, checked::Bool=true)
     end
 
     return
-end
-
-# Although excluded for reasons above, having the option to reset primary context is
-# useful nonetheless under certain circumstances.
-"""Resets the primary context on the selected device. Useful if GC fails to
-pick-up old handles despite destroying current ctx. WARNING: This can break
-automatic GC handling. Use at your own risk."""
-function resetPrimaryContext!(dev::CuDevice)
-    @apicall(:cuDevicePrimaryCtxReset, (CuDevice_t,), dev )
 end
 
 """

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -144,6 +144,23 @@ function transfer end
 @enum(CUmem_attach, ATTACH_GLOBAL = 0x01,
                     ATTACH_HOST   = 0x02)
                     #ATTACH_SINGLE = 0x04) # Defined but not valid
+@enum(CUmem_hostalloc, default       = 0x00,
+                       mapped        = 0x02,
+                       portable      = 0x01,
+                       writecombined = 0x04)
+
+function hostalloc(bytesize::Integer, flags::CUmem_hostalloc=default)
+    ptr_ref = Ref{Ptr{Cvoid}}()
+    @apicall(:cuMemAllocHost, (Ptr{Ptr{Cvoid}}, Csize_t, Cuint), ptr_ref, bytesize, flags)
+    return Buffer(ptr_ref[], bytesize, CuCurrentContext())
+end
+
+function freehost(buf::Buffer)
+    if buf.ptr != C_NULL
+    @apicall(:cuMemFreeHost, (Ptr{Cvoid},), buf.ptr)
+    end
+    return
+end
 
 """
     alloc(bytes::Integer)

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -141,6 +141,7 @@ function transfer end
 @enum(CUmem_attach, ATTACH_GLOBAL = 0x01,
                     ATTACH_HOST   = 0x02)
                     #ATTACH_SINGLE = 0x04) # Defined but not valid
+
 @enum(CUmem_hostalloc, default       = 0x00,
                        mapped        = 0x02,
                        portable      = 0x01,

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -51,3 +51,12 @@ Return the default stream.
 Wait until a stream's tasks are completed.
 """
 synchronize(s::CuStream) = @apicall(:cuStreamSynchronize, (CuStream_t,), s)
+
+"""
+    streamWaitEvent(stream::CuStream, event::CuEvent)
+
+Permits holding streams _independently_ for event triggers."""
+function streamWaitEvent(stream::CuStream, event::CuEvent; flags::Int=0)
+    @apicall(:cuStreamWaitEvent, (CuStream_t, CuEvent_t, Cuint), stream.handle,
+                                                            event.handle, flags)
+end


### PR DESCRIPTION
Re: #122

This seems to work. Only problem: I have to specify `libc.so.6` in order to call standard C-library functions. Allowing Julia to try and find it seems to fail. Any advice on how to make it "run for anyone" appreciated.
Another problem may be checking for type compatibility when transferring data to/from the buffer. At present this all assumes you know input and output types.

Have a look. Please do revise as necessary! If you think its okay, I can add some documentation for posterity and develop a simple benchmark to look at.