### PR TITLE
Cooperative Kernel Launch

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -35,8 +35,7 @@ const CuDim = Union{Integer,
                     Tuple{Integer, Integer},
                     Tuple{Integer, Integer, Integer}}
 
-# we need a generated function to get an args array,
-# without having to inspect the types at runtime
+# pack arguments in a buffer that CUDA expects
 @generated function pack_arguments(f::Function, args...)
     all(isbitstype, args) || throw(ArgumentError("Arguments to kernel should be bitstype."))
 
@@ -118,6 +117,33 @@ function launch(f::CuFunction, args...; blocks::CuDim=1, threads::CuDim=1,
     end
 end
 
+# convert the argument values to match the kernel's signature (specified by the user)
+# (this mimics `lower-ccall` in julia-syntax.scm)
+@generated function convert_arguments(f::Function, ::Type{tt}, args...) where {tt}
+    types = tt.parameters
+
+    ex = quote
+        Base.@_inline_meta
+    end
+
+    converted_args = Vector{Symbol}(undef, length(args))
+    arg_ptrs = Vector{Symbol}(undef, length(args))
+    for i in 1:length(args)
+        converted_args[i] = gensym()
+        arg_ptrs[i] = gensym()
+        push!(ex.args, :($(converted_args[i]) = Base.cconvert($(types[i]), args[$i])))
+        push!(ex.args, :($(arg_ptrs[i]) = Base.unsafe_convert($(types[i]), $(converted_args[i]))))
+    end
+
+    append!(ex.args, (quote
+        GC.@preserve $(converted_args...) begin
+            f($(arg_ptrs...))
+        end
+    end).args)
+
+    return ex
+end
+
 """
     cudacall(f::CuFunction, types, values...; blocks::CuDim, threads::CuDim,
              cooperative=false, shmem=0, stream=CuDefaultStream())
@@ -134,8 +160,7 @@ For example:
     c = zeros(Float32, 10)
     cd = Mem.alloc(c)
 
-    cudacall(vadd, (Ptr{Cfloat},Ptr{Cfloat},Ptr{Cfloat}), ad, bd, cd;
-             threads=10)
+    cudacall(vadd, (CuPtr{Cfloat},CuPtr{Cfloat},CuPtr{Cfloat}), ad, bd, cd; threads=10)
     Mem.download!(c, cd)
 
 The `blocks` and `threads` arguments control the launch configuration, and should both
@@ -145,47 +170,14 @@ being slightly faster.
 """
 cudacall
 
-@inline function cudacall(f::CuFunction, types::NTuple{N,DataType}, values::Vararg{Any,N};
-                          kwargs...) where N
-    # this cannot be inferred properly (because types only contains `DataType`s),
-    # which results in the call `@generated _cudacall` getting expanded upon first use
-    _cudacall(f, Tuple{types...}, values...; kwargs...)
-end
+# FIXME: can we make this infer properly?
+cudacall(f::CuFunction, types::Tuple, args...; kwargs...) where {N} =
+    cudacall(f, Base.to_tuple_type(types), args...; kwargs...)
 
-@inline function cudacall(f::CuFunction, tt::Type, values::Vararg{Any,N};
-                          kwargs...) where N
-    # in this case, the type of `tt` is `Tuple{<:DataType,...}`,
-    # which means the generated function can be expanded earlier
-    _cudacall(f, tt, values...; kwargs...)
-end
-
-# we need a generated function to get a tuple of converted arguments (using unsafe_convert),
-# without having to inspect the types at runtime
-@generated function _cudacall(f::CuFunction, tt::Type, args...; kwargs...)
-    types = tt.parameters[1].parameters     # the type of `tt` is Type{Tuple{<:DataType...}}
-
-    ex = quote
-        Base.@_inline_meta
+function cudacall(f::CuFunction, types::Type, args...; kwargs...)
+    convert_arguments(types, args...) do pointers...
+        launch(f, pointers...; kwargs...)
     end
-
-    # convert the argument values to match the kernel's signature (specified by the user)
-    # (this mimics `lower-ccall` in julia-syntax.scm)
-    converted_args = Vector{Symbol}(undef, length(args))
-    arg_ptrs = Vector{Symbol}(undef, length(args))
-    for i in 1:length(args)
-        converted_args[i] = gensym()
-        arg_ptrs[i] = gensym()
-        push!(ex.args, :($(converted_args[i]) = Base.cconvert($(types[i]), args[$i])))
-        push!(ex.args, :($(arg_ptrs[i]) = Base.unsafe_convert($(types[i]), $(converted_args[i]))))
-    end
-
-    append!(ex.args, (quote
-        GC.@preserve $(converted_args...) begin
-            launch(f, ($(arg_ptrs...)); kwargs...)
-        end
-    end).args)
-
-    return ex
 end
 
 

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -57,16 +57,12 @@ This is a low-level call, prefer to use [`cudacall`](@ref) instead.
     (blocks.x>0 && blocks.y>0 && blocks.z>0)    || throw(ArgumentError("Grid dimensions should be non-null"))
     (threads.x>0 && threads.y>0 && threads.z>0) || throw(ArgumentError("Block dimensions should be non-null"))
 
-    if cg
-        _launchCG(f, blocks, threads, shmem, stream, args...)
-    else
-        _launch(f, blocks, threads, shmem, stream, args...)
-    end
+    _launch(f, cg, blocks, threads, shmem, stream, args...)
 end
 
 # we need a generated function to get an args array,
 # without having to inspect the types at runtime
-@generated function _launch(f::CuFunction, blocks::CuDim3, threads::CuDim3,
+@generated function _launch(f::CuFunction, cg::Bool, blocks::CuDim3, threads::CuDim3,
                             shmem::Int, stream::CuStream,
                             args...)
     all(isbitstype, args) || throw(ArgumentError("Arguments to kernel should be bitstype."))
@@ -89,66 +85,37 @@ end
     # generate an array with pointers
     arg_ptrs = [:(Base.unsafe_convert(Ptr{Cvoid}, $(arg_refs[i]))) for i in 1:length(args)]
 
-    append!(ex.args, (quote
-        GC.@preserve $(arg_refs...) begin
-            kernelParams = [$(arg_ptrs...)]
-            @apicall(:cuLaunchKernel, (
-                CuFunction_t,           # function
-                Cuint, Cuint, Cuint,    # grid dimensions (x, y, z)
-                Cuint, Cuint, Cuint,    # block dimensions (x, y, z)
-                Cuint,                  # shared memory bytes,
-                CuStream_t,             # stream
-                Ptr{Ptr{Cvoid}},        # kernel parameters
-                Ptr{Ptr{Cvoid}}),       # extra parameters
-                f,
-                blocks.x, blocks.y, blocks.z,
-                threads.x, threads.y, threads.z,
-                shmem, stream, kernelParams, C_NULL)
-        end
-    end).args)
-
-    return ex
-end
-
-@generated function _launchCG(f::CuFunction, blocks::CuDim3, threads::CuDim3,
-                            shmem::Int, stream::CuStream,
-                            args...)
-    all(isbitstype, args) || throw(ArgumentError("Arguments to kernel should be bitstype."))
-
-    ex = quote
-        Base.@_inline_meta
-    end
-
-    # If f has N parameters, then kernelParams needs to be an array of N pointers.
-    # Each of kernelParams[0] through kernelParams[N-1] must point to a region of memory
-    # from which the actual kernel parameter will be copied.
-
-    # put arguments in Ref boxes so that we can get a pointers to them
-    arg_refs = Vector{Symbol}(undef, length(args))
-    for i in 1:length(args)
-        arg_refs[i] = gensym()
-        push!(ex.args, :($(arg_refs[i]) = Base.RefValue(args[$i])))
-    end
-
-    # generate an array with pointers
-    arg_ptrs = [:(Base.unsafe_convert(Ptr{Cvoid}, $(arg_refs[i]))) for i in 1:length(args)]
-
-    append!(ex.args, (quote
-        GC.@preserve $(arg_refs...) begin
-            kernelParams = [$(arg_ptrs...)]
-            @apicall(:cuLaunchCooperativeKernel, (
-                CuFunction_t,           # function
-                Cuint, Cuint, Cuint,    # grid dimensions (x, y, z)
-                Cuint, Cuint, Cuint,    # block dimensions (x, y, z)
-                Cuint,                  # shared memory bytes,
-                CuStream_t,             # stream
-                Ptr{Ptr{Cvoid}}),        # kernel parameters
-                f,
-                blocks.x, blocks.y, blocks.z,
-                threads.x, threads.y, threads.z,
-                shmem, stream, kernelParams)
-        end
-    end).args)
+        append!(ex.args, (quote
+            GC.@preserve $(arg_refs...) begin
+                kernelParams = [$(arg_ptrs...)]
+                if cg  # Note that cooperative kernel has 1 less arguments.
+                    @apicall(:cuLaunchCooperativeKernel, (
+                        CuFunction_t,           # function
+                        Cuint, Cuint, Cuint,    # grid dimensions (x, y, z)
+                        Cuint, Cuint, Cuint,    # block dimensions (x, y, z)
+                        Cuint,                  # shared memory bytes,
+                        CuStream_t,             # stream
+                        Ptr{Ptr{Cvoid}}),        # kernel parameters
+                        f,
+                        blocks.x, blocks.y, blocks.z,
+                        threads.x, threads.y, threads.z,
+                        shmem, stream, kernelParams)
+                else
+                    @apicall(:cuLaunchKernel, (
+                        CuFunction_t,           # function
+                        Cuint, Cuint, Cuint,    # grid dimensions (x, y, z)
+                        Cuint, Cuint, Cuint,    # block dimensions (x, y, z)
+                        Cuint,                  # shared memory bytes,
+                        CuStream_t,             # stream
+                        Ptr{Ptr{Cvoid}},        # kernel parameters
+                        Ptr{Ptr{Cvoid}}),       # extra parameters
+                        f,
+                        blocks.x, blocks.y, blocks.z,
+                        threads.x, threads.y, threads.z,
+                        shmem, stream, kernelParams, C_NULL)
+                end
+            end
+        end).args)
 
     return ex
 end

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -49,7 +49,7 @@ internal kernel parameter buffer, or a pointer to device memory.
 
 This is a low-level call, prefer to use [`cudacall`](@ref) instead.
 """
-@inline function launch(f::CuFunction, cg::Bool, blocks::CuDim, threads::CuDim,
+@inline function launch(f::CuFunction, cooperative::Bool, blocks::CuDim, threads::CuDim,
                         shmem::Int, stream::CuStream,
                         args...)
     blocks = CuDim3(blocks)
@@ -57,12 +57,12 @@ This is a low-level call, prefer to use [`cudacall`](@ref) instead.
     (blocks.x>0 && blocks.y>0 && blocks.z>0)    || throw(ArgumentError("Grid dimensions should be non-null"))
     (threads.x>0 && threads.y>0 && threads.z>0) || throw(ArgumentError("Block dimensions should be non-null"))
 
-    _launch(f, cg, blocks, threads, shmem, stream, args...)
+    _launch(f, cooperative, blocks, threads, shmem, stream, args...)
 end
 
 # we need a generated function to get an args array,
 # without having to inspect the types at runtime
-@generated function _launch(f::CuFunction, cg::Bool, blocks::CuDim3, threads::CuDim3,
+@generated function _launch(f::CuFunction, cooperative::Bool, blocks::CuDim3, threads::CuDim3,
                             shmem::Int, stream::CuStream,
                             args...)
     all(isbitstype, args) || throw(ArgumentError("Arguments to kernel should be bitstype."))
@@ -88,7 +88,7 @@ end
         append!(ex.args, (quote
             GC.@preserve $(arg_refs...) begin
                 kernelParams = [$(arg_ptrs...)]
-                if cg  # Note that cooperative kernel has 1 less arguments.
+                if cooperative  # Note that cooperative kernel has 1 less arguments.
                     @apicall(:cuLaunchCooperativeKernel, (
                         CuFunction_t,           # function
                         Cuint, Cuint, Cuint,    # grid dimensions (x, y, z)
@@ -164,7 +164,7 @@ end
 # we need a generated function to get a tuple of converted arguments (using unsafe_convert),
 # without having to inspect the types at runtime
 @generated function _cudacall(f::CuFunction, tt::Type, args...;
-                              cg::Bool=false, blocks::CuDim=1, threads::CuDim=1,
+                              cooperative::Bool=false, blocks::CuDim=1, threads::CuDim=1,
                               shmem::Integer=0, stream::CuStream=CuDefaultStream())
     types = tt.parameters[1].parameters     # the type of `tt` is Type{Tuple{<:DataType...}}
 
@@ -185,7 +185,7 @@ end
 
     append!(ex.args, (quote
         GC.@preserve $(converted_args...) begin
-            launch(f, cg, blocks, threads, shmem, stream, ($(arg_ptrs...)))
+            launch(f, cooperative, blocks, threads, shmem, stream, ($(arg_ptrs...)))
         end
     end).args)
 

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -33,7 +33,9 @@ let
     cudacall(dummy, (); threads=1, blocks=1, shmem=0, stream=CuDefaultStream())
 
     # different launch syntaxes
-    CUDAdrv.launch(dummy, 1, 1, 0, CuDefaultStream(), ())
+    CUDAdrv.launch(dummy, true, 1, 1, 0, CuDefaultStream(), ())
+    CUDAdrv.launch(dummy, false, 1, 1, 0, CuDefaultStream(), ())
+
 end
 
 let

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -29,13 +29,17 @@ let
     cudacall(dummy, Tuple{}; threads=1, blocks=1)
     cudacall(dummy, Tuple{}; threads=1, blocks=1, shmem=0)
     cudacall(dummy, Tuple{}; threads=1, blocks=1, shmem=0, stream=CuDefaultStream())
+    cudacall(dummy, Tuple{}; threads=1, blocks=1, shmem=0, stream=CuDefaultStream(), cooperative=false)
     cudacall(dummy, ())
-    cudacall(dummy, (); threads=1, blocks=1, shmem=0, stream=CuDefaultStream())
+    cudacall(dummy, (); threads=1, blocks=1, shmem=0, stream=CuDefaultStream(), cooperative=false)
 
     # different launch syntaxes
-    CUDAdrv.launch(dummy, true, 1, 1, 0, CuDefaultStream(), ())
-    CUDAdrv.launch(dummy, false, 1, 1, 0, CuDefaultStream(), ())
-
+    CUDAdrv.launch(dummy)
+    CUDAdrv.launch(dummy; threads=1)
+    CUDAdrv.launch(dummy; threads=1, blocks=1)
+    CUDAdrv.launch(dummy; threads=1, blocks=1, shmem=0)
+    CUDAdrv.launch(dummy; threads=1, blocks=1, shmem=0, stream=CuDefaultStream())
+    CUDAdrv.launch(dummy; threads=1, blocks=1, shmem=0, stream=CuDefaultStream(), cooperative=false)
 end
 
 let


### PR DESCRIPTION
Now functions in src/execution.jl accepts a `cg::Bool` argument that will allow `_launch()` to call the cooperative kernel launch if set to `true`. Note that some other functions depend on launch may break, for example, the test for `launch()`, which is modified accordingly.