### PR TITLE
Escape stream in elapsed macro

### DIFF
--- a/src/events.jl
+++ b/src/events.jl
@@ -92,9 +92,9 @@ number of seconds it took to execute on the GPU, as a floating-point number.
 macro elapsed(stream, ex)
     quote
         t0, t1 = CuEvent(), CuEvent()
-        record(t0, $stream)
+        record(t0, $(esc(stream)))
         $(esc(ex))
-        record(t1, $stream)
+        record(t1, $(esc(stream)))
         synchronize(t1)
         elapsed(t0, t1)
     end

--- a/test/events.jl
+++ b/test/events.jl
@@ -29,4 +29,9 @@ CuEvent(CUDAdrv.EVENT_BLOCKING_SYNC | CUDAdrv.EVENT_DISABLE_TIMING)
     synchronize()
 end
 
+@testset "elapsed stream" begin
+    stream = CuStream()
+    @test (CUDAdrv.@elapsed stream begin end) > 0
+end
+
 end


### PR DESCRIPTION
This allows streams not in global scope to be passed into `@elapsed`.