### PR TITLE
Try to unsafe_convert PtrOrCuPtr in opposite order

### DIFF
--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -111,10 +111,10 @@ end
 
 function Base.unsafe_convert(::Type{PtrOrCuPtr{T}}, val) where {T}
     # TODO: this should try/catch since the fallback for `unsafe_convert{Ptr}` calls error
-    ptr = if applicable(Base.unsafe_convert, CuPtr{T}, val)
-        Base.unsafe_convert(CuPtr{T}, val)
-    elseif applicable(Base.unsafe_convert, Ptr{T}, val)
+    ptr = if applicable(Base.unsafe_convert, Ptr{T}, val)
         Base.unsafe_convert(Ptr{T}, val)
+    elseif applicable(Base.unsafe_convert, CuPtr{T}, val)
+        Base.unsafe_convert(CuPtr{T}, val)
     else
         throw(ArgumentError("cannot convert to either a CPU or GPU pointer"))
     end


### PR DESCRIPTION
When applicable is false it does more than 40 allocations and allocates several KB. When it is true it does 1 very small allocation. It is also slower when it is false. As far as I can tell PtrOrCuPtr seems to only really be used for passing constants into CUBLAS functions in CuArrays. All of the high level wrappers for CUBLAS expect those constants to be on the CPU so checking the CPU conversion first makes those calls faster and allocate less.

It's not a big difference, but I had some code that made a bunch of BLAS calls and used pretty small arrays to make the tests go quick. In that case it makes a quite noticeable speed difference.