### PR TITLE
Fix the conversion to PtrOrCuPtr.

### DIFF
--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -110,7 +110,7 @@ function Base.cconvert(::Type{PtrOrCuPtr{T}}, val) where {T}
 end
 
 function Base.unsafe_convert(::Type{PtrOrCuPtr{T}}, val) where {T}
-    # FIXME: this is expensive
+    # FIXME: this is expensive; optimize using isapplicable?
     ptr = try
         Base.unsafe_convert(Ptr{T}, val)
     catch

--- a/test/array.jl
+++ b/test/array.jl
@@ -13,6 +13,9 @@ mutable struct CuTestArray{T,N}
         finalizer(unsafe_free!, obj)
         return obj
     end
+    function CuTestArray{T,N}(buf::Mem.DeviceBuffer, shape::NTuple{N,Int}) where {T,N}
+        new{T,N}(buf, shape)
+    end
 end
 
 function unsafe_free!(a::CuTestArray)

--- a/test/pointer.jl
+++ b/test/pointer.jl
@@ -1,30 +1,41 @@
 @testset "pointer" begin
 
 # constructors
-
-voidptr_a = CuPtr{Cvoid,AS.Host}(Int(0xDEADBEEF))
-@test voidptr_a == CuHostPtr{Cvoid}(Int(0xDEADBEEF))
-
-voidptr_b = CuPtr{Cvoid,AS.Host}(Int(0xCAFEBABE))
-@test voidptr_b == CuHostPtr{Cvoid}(Int(0xCAFEBABE))
+voidptr_a = CuPtr{Cvoid}(Int(0xDEADBEEF))
+@test reinterpret(Ptr{Cvoid}, voidptr_a) == Ptr{Cvoid}(Int(0xDEADBEEF))
 
 # getters
 @test eltype(voidptr_a) == Cvoid
 
 # comparisons
+voidptr_b = CuPtr{Cvoid}(Int(0xCAFEBABE))
 @test voidptr_a != voidptr_b
 
 
 @testset "conversions" begin
 
 # between regular and CUDA pointers
-
-@test_throws ArgumentError convert(Ptr{Cvoid}, voidptr_device_a)
+@test_throws ArgumentError convert(Ptr{Cvoid}, voidptr_a)
 
 # between CUDA pointers
-
-intptr_a = CuPtr{Int,AS.Host}(Int(0xDEADBEEF))
+intptr_a = CuPtr{Int}(Int(0xDEADBEEF))
 @test convert(typeof(intptr_a), voidptr_a) == intptr_a
+
+end
+
+
+@testset "GPU or CPU integration" begin
+
+a = [1]
+ccall(:clock, Nothing, (Ptr{Int},), a)
+@test_throws Exception ccall(:clock, Nothing, (CuPtr{Int},), a)
+ccall(:clock, Nothing, (CUDAdrv.PtrOrCuPtr{Int},), a)
+
+buf = Mem.DeviceBuffer(CU_NULL, 0, CuContext(C_NULL))
+b = CuTestArray{eltype(a), ndims(a)}(buf, size(a))
+ccall(:clock, Nothing, (CuPtr{Int},), b)
+@test_throws Exception ccall(:clock, Nothing, (Ptr{Int},), b)
+ccall(:clock, Nothing, (CUDAdrv.PtrOrCuPtr{Int},), b)
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ include("util.jl")
 include("array.jl")
 
 include("base.jl")
+include("pointer.jl")
 
 if CUDAdrv.configured
     @test length(devices()) > 0


### PR DESCRIPTION
Fix https://github.com/JuliaGPU/CuArrays.jl/pull/330#issuecomment-498864179 (cc @jutho).

```julia
julia> using CuArrays, CUDAdrv
[ Info: Recompiling stale cache file /home/tbesard/Julia/depot/compiled/v1.1/CuArrays/7YFE0.ji for CuArrays [3a865a2d-5b23-5a0f-bc46-62713ec82fae]

julia> a = [1]
1-element Array{Int64,1}:
 1

julia> ccall(:clock, Nothing, (Ptr{Int},), a)

julia> ccall(:clock, Nothing, (CuPtr{Int},), a)
ERROR: MethodError: no method matching unsafe_convert(::Type{CuPtr{Int64}}, ::Array{Int64,1})
Closest candidates are:
  unsafe_convert(::Type{Ptr{T}}, ::Array{T,N} where N) where T at pointer.jl:65
  unsafe_convert(::Type{Ptr{T}}, ::AbstractArray{T,N} where N) where T at pointer.jl:67
  unsafe_convert(::Type{Ptr{S}}, ::AbstractArray{T,N} where N) where {S, T} at pointer.jl:66
  ...
Stacktrace:
 [1] top-level scope at ./none:0

julia> ccall(:clock, Nothing, (CUDAdrv.PtrOrCuPtr{Int},), a)

julia> b = CuArray(a)
1-element CuArray{Int64,1}:
 1

julia> ccall(:clock, Nothing, (CuPtr{Int},), b)

julia> ccall(:clock, Nothing, (Ptr{Int},), b)
ERROR: ArgumentError: cannot take the CPU address of a CuArray{Int64,1}
Stacktrace:
 [1] cconvert(::Type{Ptr{Int64}}, ::CuArray{Int64,1}) at /home/tbesard/Julia/CuArrays/src/array.jl:152
 [2] top-level scope at ./none:0

julia> ccall(:clock, Nothing, (CUDAdrv.PtrOrCuPtr{Int},), b)
```

Still needs tests. Performance of the worst case (failed conversion to regular `Ptr`) is pretty bad though:

```julia
julia> using BenchmarkTools

julia> @btime ccall(:clock, Nothing, (Ptr{Int},), a)
  312.625 ns (1 allocation: 16 bytes)

julia> @btime ccall(:clock, Nothing, (CuPtr{Int},), b)
  429.663 ns (2 allocations: 48 bytes)

julia> @btime ccall(:clock, Nothing, (CUDAdrv.PtrOrCuPtr{Int},), a)
  399.440 ns (1 allocation: 16 bytes)

julia> @btime ccall(:clock, Nothing, (CUDAdrv.PtrOrCuPtr{Int},), b)
  20.794 μs (3 allocations: 64 bytes)
```

I'll try adding some `isapplicable` fast paths.