### PR TITLE
Nsight Systems profiler integration.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,6 @@ version = "3.1.0"
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 CUDAapi = "3895d2a7-ec45-59b8-82bb-cfc6a382f9b3"
-Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "3.1.0"
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 CUDAapi = "3895d2a7-ec45-59b8-82bb-cfc6a382f9b3"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 

--- a/src/CUDAdrv.jl
+++ b/src/CUDAdrv.jl
@@ -5,7 +5,6 @@ using CUDAapi
 using CEnum
 
 using Printf
-using Libdl
 
 
 ## discovery

--- a/src/profile.jl
+++ b/src/profile.jl
@@ -43,7 +43,8 @@ function start()
         @warn("""Calling CUDAdrv.@profile only informs an external profiler to start.
                  The user is responsible for launching Julia under a CUDA profiler like `nvprof`.
 
-                 For improved usability, launch Julia under the Nsight Systems profiler.""",
+                 For improved usability, launch Julia under the Nsight Systems profiler:
+                 nsys launch -t cuda,cublas,cudnn,nvtx julia""",
               maxlog=1)
     end
     CUDAdrv.cuProfilerStart()
@@ -58,6 +59,7 @@ profiling is already disabled, then this call has no effect.
 function stop()
     if nsight[] !== nothing
         run(`$(nsight[]) stop`)
+        @info "Profiling has finished, open the report listed above with `nsight-sys`"
     else
         CUDAdrv.cuProfilerStop()
     end

--- a/src/profile.jl
+++ b/src/profile.jl
@@ -25,7 +25,6 @@ end
 module Profile
 
 using ..CUDAdrv
-using Distributed, Libdl
 
 const nsight = Ref{Union{Nothing,String}}(nothing)
 
@@ -67,19 +66,16 @@ end
 
 function __init__()
     # find the active Nsight Systems profiler
-    libs = Libdl.dllist()
-    filter!(path->occursin("ToolsInjection", basename(path)), libs)
-    if isempty(libs)
-        nsight[] = nothing
-    else
-        dirs = unique(map(dirname, libs))
-        @assert length(dirs) == 1
-        dir = dirs[1]
+    if haskey(ENV, "CUDA_INJECTION64_PATH")
+        lib = ENV["CUDA_INJECTION64_PATH"]
+        dir = dirname(lib)
 
         nsight[] = joinpath(dir, "nsys")
         @assert isfile(nsight[])
 
         @info "Running under Nsight Systems, CUDAdrv.@profile will automatically start the profiler"
+    else
+        nsight[] = nothing
     end
 end
 

--- a/src/profile.jl
+++ b/src/profile.jl
@@ -25,6 +25,15 @@ end
 module Profile
 
 using ..CUDAdrv
+using Distributed, Libdl
+
+const nsight = Ref{Union{Nothing,String}}(nothing)
+
+# use a separate process to communicate with nsight to work around
+# https://devtalk.nvidia.com/default/topic/1065305/
+#
+# note that other process spawning is still broken, and e.g. precompilation does not work
+const child = Ref{Int}()
 
 
 """
@@ -33,7 +42,23 @@ using ..CUDAdrv
 Enables profile collection by the active profiling tool for the current context. If
 profiling is already enabled, then this call has no effect.
 """
-start() = CUDAdrv.cuProfilerStart()
+function start()
+    # make sure the stop call is precompiled
+    stop()
+
+    if nsight[] !== nothing
+        remotecall_wait(child[], nsight[]) do nsight
+            run(`$nsight start -c cudaProfilerApi`)
+        end
+    else
+        @warn("""Calling CUDAdrv.@profile only informs an external profiler to start.
+                 The user is responsible for launching Julia under a CUDA profiler like `nvprof`.
+
+                 For improved usability, launch Julia under the Nsight Systems profiler.""",
+              maxlog=1)
+    end
+    CUDAdrv.cuProfilerStart()
+end
 
 """
     stop()
@@ -42,5 +67,27 @@ Disables profile collection by the active profiling tool for the current context
 profiling is already disabled, then this call has no effect.
 """
 stop() = CUDAdrv.cuProfilerStop()
+
+function __init__()
+    # find the active Nsight Systems profiler
+    libs = Libdl.dllist()
+    filter!(path->occursin("ToolsInjection", basename(path)), libs)
+    if isempty(libs)
+        nsight[] = nothing
+    else
+        dirs = unique(map(dirname, libs))
+        @assert length(dirs) == 1
+        dir = dirs[1]
+
+        nsight[] = joinpath(dir, "nsys")
+        @assert isfile(nsight[])
+
+        child[] = withenv("LD_PRELOAD" => nothing) do
+            addprocs(1)[1]
+        end
+
+        @info "Running under Nsight Systems, CUDAdrv.@profile will automatically start the profiler"
+    end
+end
 
 end


### PR DESCRIPTION
This PR aims to integrate with the new Nsight Systems profiler, which features a useful mode where you can launch an interactive process and start profiling afterwards. This makes it possible to launch a long-running session under the profiler, and decide to capture data independently without the need to restart your Julia session:

```
$ ~/nsight-systems-2019.5.1/bin/nsys launch julia

**** launch command configuration ****
        inherit-environment = true
        show-output = true
        trace-fork-before-exec = false
        sample_cpu = true
        backtrace_method = LBR
        wait = all
        trace_cublas = true
        trace_cuda = true
        trace_cudnn = false
        trace_nvtx = true
        trace_mpi = false
        trace_openacc = false
        trace_vulkan = false
        trace_opengl = false
        trace_osrt = false
        osrt-threshold = 0 nanoseconds
        cudabacktrace = false
        cudabacktrace-threshold = 0 nanoseconds
        profile_processes = tree
        application command = julia
        application arguments = 
        application working directory = /home/tim/Julia/pkg/CuArrays
        NVTX profiler range trigger = 
        NVTX profiler domain trigger = 
        environment variables:
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.3.0-rc4.1 (2019-10-15)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> using Revise

julia> Revise.includet("wip.jl")

# do some development

julia> main()

# time to profile!

julia> CUDAdrv.@profile main()
  0.072424 seconds (60.08 k CPU allocations: 1.986 MiB) (3 GPU allocations: 507.813 KiB, 1.68% gc time of which 97.82% spent allocating)
  0.000502 seconds (35 CPU allocations: 79.047 KiB) (2 GPU allocations: 117.188 KiB, 5.06% gc time of which 74.22% spent allocating)

**** start command configuration ****
        force-overwrite = false
        stop-on-exit = true
        export_sqlite = false
        stats = false
        capture-range = cudaProfilerApi
        stop-on-range-end = true
        Beta: ftrace events:
        ftrace-keep-user-config = false
        trace-GPU-context-switch = false
      From worker 2:
      From worker 2:    WARNING: CUDA tracing is required for cudaProfilerStart/Stop API support. Turning it on by default.
      From worker 2:    waiting for capture range to start the collection
        Capture range started in the application.
        Collecting data...
  0.119898 seconds (60.06 k CPU allocations: 1.986 MiB) (3 GPU allocations: 507.813 KiB, 0.02% gc time)
  0.000458 seconds (30 CPU allocations: 78.953 KiB) (2 GPU allocations: 117.188 KiB, 1.25% gc time)
        Capture range ended in the application
        Generating the /home/tim/Julia/pkg/CuArrays/report8.qdstrm file.
        Capturing raw events...
        2873 total events collected.
        Capturing symbol files...
        Saving diagnostics...
        Saving qdstrm file to disk...
        Finished saving file.


Importing the qdstrm file using /home/tim/nsight-systems-2019.5.1/host-linux-x64/QdstrmImporter.

Importing...

Importing [==================================================100%]
Saving report to file "/home/tim/Julia/pkg/CuArrays/report8.qdrep"
Report file saved.
Please discard the qdstrm file and use the qdrep file instead.

Removed /home/tim/Julia/pkg/CuArrays/report8.qdstrm as it was successfully imported.
Please use the qdrep file instead.

> julia

# do some more development
```

Now we can open this report without disrupting our Julia session:

![Screenshot_20191023_094233](https://user-images.githubusercontent.com/383068/67369532-75efab80-f579-11e9-8f37-6eacd0f7a26b.png)

Important limitation: spawning commands from Julia [kills the profiler](https://devtalk.nvidia.com/default/topic/1065305/), which includes precompilation of code. So make sure your code is precompiled before running under `nsys launch`.

You can download the latest version of Nsight Systems [here](https://developer.nvidia.com/gameworksdownload#?dn=nsight-systems-2019-5), for which you need a NVIDIA developer account. An older version is shipped as part of CUDA 10.1, but it's in heavy development so I recommend using the latest version.