### PR TITLE
add query for stream and event

### DIFF
--- a/src/error.jl
+++ b/src/error.jl
@@ -147,15 +147,16 @@ macro checked(ex)
 
     # generate a "safe" version that performs a check
     safe_body = Expr(:block, body.args[1], :(@check $(body.args[2])))
-    safe_def = Expr(:function, sig, safe_body)
+    safe_sig = Expr(:call, esc(sig.args[1]), sig.args[2:end]...)
+    safe_def = Expr(:function, safe_sig, safe_body)
 
     # generate a "unsafe" version that returns the error code instead
-    unsafe_sig = Expr(:call, Symbol("unsafe_$(sig.args[1])"), sig.args[2:end]...)
+    unsafe_sig = Expr(:call, esc(Symbol("unsafe_", sig.args[1])), sig.args[2:end]...)
     unsafe_def = Expr(:function, unsafe_sig, body)
 
     return quote
-        @eval $safe_def
-        @eval $unsafe_def
+        $safe_def
+        $unsafe_def
     end
 end
 

--- a/src/events.jl
+++ b/src/events.jl
@@ -52,6 +52,23 @@ Waits for an event to complete.
 synchronize(e::CuEvent) = cuEventSynchronize(e)
 
 """
+    query(e::CuEvent)
+
+Return `false` if there is outstanding work preceding the most recent
+call to `record(e)` and `true` if all captured work has been completed.
+"""
+function query(e::CuEvent)
+    err = unsafe_cuEventQuery(e)
+    if err === CUDA_ERROR_NOT_READY
+        return false
+    elseif err === CUDA_SUCCESS
+        return true
+    else
+        throw_api_error(err)
+    end
+end
+
+"""
     wait(e::CuEvent, stream=CuDefaultStream())
 
 Make a stream wait on a event. This only makes the stream wait, and not the host; use

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -50,3 +50,20 @@ Return the default stream.
 Wait until a stream's tasks are completed.
 """
 synchronize(s::CuStream) = cuStreamSynchronize(s)
+
+"""
+    query(s::CuStream)
+
+Return `false` if a stream is busy (has task running or queued)
+and `true` if that stream is free.
+"""
+function query(s::CuStream)
+    err = unsafe_cuStreamQuery(s)
+    if err === CUDA_ERROR_NOT_READY
+        return false
+    elseif err === CUDA_SUCCESS
+        return true
+    else
+        throw_api_error(err)
+    end
+end

--- a/test/events.jl
+++ b/test/events.jl
@@ -29,6 +29,11 @@ CuEvent(CUDAdrv.EVENT_BLOCKING_SYNC | CUDAdrv.EVENT_DISABLE_TIMING)
     synchronize()
 end
 
+@testset "event query" begin
+    event  = CuEvent()
+    @test CUDAdrv.query(event) == true
+end
+
 @testset "elapsed stream" begin
     stream = CuStream()
     @test (CUDAdrv.@elapsed stream begin end) > 0

--- a/test/stream.jl
+++ b/test/stream.jl
@@ -3,6 +3,8 @@
 let
     s = CuStream()
     synchronize(s)
+    @test CUDAdrv.query(s) == true
+
     let s2 = CuStream()
         @test s != s2
     end


### PR DESCRIPTION
While implementing an MPI friendly `synchronize(stream)`, I noticed that the API swallows the error code that query is supposed to return. x-ref: https://github.com/climate-machine/CLIMA/pull/439/commits/a4a6c1610767f61da69564e5a862995ee89368ac#diff-f93e99470aee8fd224be784002b3054dR169