### PR TITLE
Fix version check

### DIFF
--- a/src/CUDAdrv.jl
+++ b/src/CUDAdrv.jl
@@ -53,7 +53,7 @@ function __init__()
 
         cuInit(0)
 
-        if version() <= v"9"
+        if version() < v"9"
             silent || @warn "CUDAdrv.jl only supports NVIDIA drivers for CUDA 9.0 or higher (yours is for CUDA $(version()))"
         end
 


### PR DESCRIPTION
I was getting
```
┌ Warning: CUDAdrv.jl only supports NVIDIA drivers for CUDA 9.0 or higher (yours is for CUDA 9.0.0)
└ @ CUDAdrv ~/.julia/dev/CUDAdrv/src/CUDAdrv.jl:57
```
