### PR TITLE
add Mem.pin that tracks registered Arrays

### DIFF
--- a/src/memory.jl
+++ b/src/memory.jl
@@ -185,7 +185,7 @@ end
 # - Deal with memory regions/views
 const __pinned_memory = Dict{Ptr, WeakRef}()
 
-function pin(a, flags=0)
+function pin(a::Array, flags=0)
     # use pointer instead of objectid?
     oid = pointer(a)
     if haskey(__pinned_memory, oid) && __pinned_memory[oid].value !== nothing

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -185,13 +185,13 @@ end
 # - Deal with memory regions/views
 const __pinned_memory = Dict{Ptr, WeakRef}()
 
-function pin(a)
+function pin(a, flags=0)
     # use pointer instead of objectid?
     oid = pointer(a)
     if haskey(__pinned_memory, oid) && __pinned_memory[oid].value !== nothing
         return nothing
     end
-    ad = Mem.register(Mem.Host, pointer(a), sizeof(a))
+    ad = Mem.register(Mem.Host, pointer(a), sizeof(a), flags)
     finalizer(_ -> Mem.unregister(ad), a)
     __pinned_memory[oid] = WeakRef(a)
     return nothing

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -187,13 +187,13 @@ const __pinned_memory = Dict{Ptr, WeakRef}()
 
 function pin(a::Array, flags=0)
     # use pointer instead of objectid?
-    oid = pointer(a)
-    if haskey(__pinned_memory, oid) && __pinned_memory[oid].value !== nothing
+    ptr = pointer(a)
+    if haskey(__pinned_memory, ptr) && __pinned_memory[ptr].value !== nothing
         return nothing
     end
     ad = Mem.register(Mem.Host, pointer(a), sizeof(a), flags)
     finalizer(_ -> Mem.unregister(ad), a)
-    __pinned_memory[oid] = WeakRef(a)
+    __pinned_memory[ptr] = WeakRef(a)
     return nothing
 end
 

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -183,11 +183,11 @@ end
 # - WeakRef dict does not unique the key by objectid
 # TODO:
 # - Deal with memory regions/views
-const __pinned_memory = Dict{UInt64, WeakRef}()
+const __pinned_memory = Dict{Ptr, WeakRef}()
 
 function pin(a)
     # use pointer instead of objectid?
-    oid = objectid(a)
+    oid = pointer(a)
     if haskey(__pinned_memory, oid) && __pinned_memory[oid].value !== nothing
         return nothing
     end


### PR DESCRIPTION
This is needed in KernelAbstractions for `async_copy` since
that needs to be to and from registered memory regions,
and @kshyatt needed something like this for her work as well.

Putting this up so that we can discuss implementation and location of the code.